### PR TITLE
Fix for Mozilla CA bundle on Fedora/CentOS

### DIFF
--- a/packer/http/centos-6.6/ks-ganeti.cfg
+++ b/packer/http/centos-6.6/ks-ganeti.cfg
@@ -29,7 +29,7 @@ openssh-clients
 sudo
 wget
 nfs-utils
-perl
+perl-libwww-perl
 rsync
 vim
 man

--- a/packer/http/centos-6.6/ks-ganeti.cfg
+++ b/packer/http/centos-6.6/ks-ganeti.cfg
@@ -29,6 +29,7 @@ openssh-clients
 sudo
 wget
 nfs-utils
+perl
 rsync
 vim
 man

--- a/packer/http/centos-6.6/ks-ganeti.cfg
+++ b/packer/http/centos-6.6/ks-ganeti.cfg
@@ -67,7 +67,9 @@ man-pages
 %post
 yum -y upgrade
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
+wget https://raw.githubusercontent.com/bagder/curl/master/lib/mk-ca-bundle.pl
+perl mk-ca-bundle.pl /etc/pki/tls/certs/ca-bundle.crt
+rm certdata.txt mk-ca-bundle.pl
 # sudo
 echo "%osuadmin ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/osuadmin
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/centos-6.6/ks-openstack.cfg
+++ b/packer/http/centos-6.6/ks-openstack.cfg
@@ -27,7 +27,7 @@ openssh-clients
 sudo
 wget
 nfs-utils
-perl
+perl-libwww-perl
 rsync
 vim
 man

--- a/packer/http/centos-6.6/ks-openstack.cfg
+++ b/packer/http/centos-6.6/ks-openstack.cfg
@@ -27,6 +27,7 @@ openssh-clients
 sudo
 wget
 nfs-utils
+perl
 rsync
 vim
 man

--- a/packer/http/centos-6.6/ks-openstack.cfg
+++ b/packer/http/centos-6.6/ks-openstack.cfg
@@ -65,7 +65,9 @@ man-pages
 %post
 yum -y upgrade
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
+wget https://raw.githubusercontent.com/bagder/curl/master/lib/mk-ca-bundle.pl
+perl mk-ca-bundle.pl /etc/pki/tls/certs/ca-bundle.crt
+rm certdata.txt mk-ca-bundle.pl
 # sudo
 echo "%centos ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/centos-7.0/ks-ganeti.cfg
+++ b/packer/http/centos-7.0/ks-ganeti.cfg
@@ -78,7 +78,9 @@ man-pages
 
 %post
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
+wget https://raw.githubusercontent.com/bagder/curl/master/lib/mk-ca-bundle.pl
+perl mk-ca-bundle.pl /etc/pki/tls/certs/ca-bundle.crt
+rm certdata.txt mk-ca-bundle.pl
 # sudo
 echo "%osuadmin ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/osuadmin
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/centos-7.0/ks-openstack.cfg
+++ b/packer/http/centos-7.0/ks-openstack.cfg
@@ -75,7 +75,9 @@ man-pages
 
 %post
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
+wget https://raw.githubusercontent.com/bagder/curl/master/lib/mk-ca-bundle.pl
+perl mk-ca-bundle.pl /etc/pki/tls/certs/ca-bundle.crt
+rm certdata.txt mk-ca-bundle.pl
 # sudo
 echo "%centos ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/centos
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/centos-7.1/ks-ganeti.cfg
+++ b/packer/http/centos-7.1/ks-ganeti.cfg
@@ -31,7 +31,7 @@ sudo
 wget
 nfs-utils
 net-tools
-perl
+perl-libwww-perl
 bzip2
 vim
 rsync

--- a/packer/http/centos-7.1/ks-ganeti.cfg
+++ b/packer/http/centos-7.1/ks-ganeti.cfg
@@ -80,7 +80,9 @@ man-pages
 %post
 yum -y upgrade
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
+wget https://raw.githubusercontent.com/bagder/curl/master/lib/mk-ca-bundle.pl
+perl mk-ca-bundle.pl /etc/pki/tls/certs/ca-bundle.crt
+rm certdata.txt mk-ca-bundle.pl
 # sudo
 echo "%osuadmin ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/osuadmin
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/centos-7.1/ks-ganeti.cfg
+++ b/packer/http/centos-7.1/ks-ganeti.cfg
@@ -31,6 +31,7 @@ sudo
 wget
 nfs-utils
 net-tools
+perl
 bzip2
 vim
 rsync

--- a/packer/http/centos-7.1/ks-openstack.cfg
+++ b/packer/http/centos-7.1/ks-openstack.cfg
@@ -27,6 +27,7 @@ sudo
 wget
 nfs-utils
 net-tools
+perl
 bzip2
 vim
 rsync

--- a/packer/http/centos-7.1/ks-openstack.cfg
+++ b/packer/http/centos-7.1/ks-openstack.cfg
@@ -76,7 +76,9 @@ man-pages
 %post
 yum -y upgrade
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
+wget https://raw.githubusercontent.com/bagder/curl/master/lib/mk-ca-bundle.pl
+perl mk-ca-bundle.pl /etc/pki/tls/certs/ca-bundle.crt
+rm certdata.txt mk-ca-bundle.pl
 # sudo
 echo "%centos ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/centos
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/centos-7.1/ks-openstack.cfg
+++ b/packer/http/centos-7.1/ks-openstack.cfg
@@ -27,7 +27,7 @@ sudo
 wget
 nfs-utils
 net-tools
-perl
+perl-libwww-perl
 bzip2
 vim
 rsync

--- a/packer/http/fedora-21/ks-openstack.cfg
+++ b/packer/http/fedora-21/ks-openstack.cfg
@@ -36,7 +36,9 @@ wget
 
 %post
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
+wget https://raw.githubusercontent.com/bagder/curl/master/lib/mk-ca-bundle.pl
+perl mk-ca-bundle.pl /etc/pki/tls/certs/ca-bundle.crt
+rm certdata.txt mk-ca-bundle.pl
 # sudo
 echo 'Defaults:fedora !requiretty' > /etc/sudoers.d/fedora
 echo '%fedora ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/fedora

--- a/packer/http/fedora-21/ks-openstack.cfg
+++ b/packer/http/fedora-21/ks-openstack.cfg
@@ -28,7 +28,7 @@ man
 man-pages
 net-tools
 nfs-utils
-perl
+perl-libwww-perl
 rsync
 tar
 vim

--- a/packer/http/fedora-21/ks-openstack.cfg
+++ b/packer/http/fedora-21/ks-openstack.cfg
@@ -28,6 +28,7 @@ man
 man-pages
 net-tools
 nfs-utils
+perl
 rsync
 tar
 vim

--- a/packer/http/fedora-22/ks-ganeti.cfg
+++ b/packer/http/fedora-22/ks-ganeti.cfg
@@ -38,7 +38,9 @@ wget
 
 %post
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
+wget https://raw.githubusercontent.com/bagder/curl/master/lib/mk-ca-bundle.pl
+perl mk-ca-bundle.pl /etc/pki/tls/certs/ca-bundle.crt
+rm certdata.txt mk-ca-bundle.pl
 # sudo
 echo "%osuadmin ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/osuadmin
 sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers

--- a/packer/http/fedora-22/ks-ganeti.cfg
+++ b/packer/http/fedora-22/ks-ganeti.cfg
@@ -30,6 +30,7 @@ man
 man-pages
 net-tools
 nfs-utils
+perl-libwww-perl
 rsync
 tar
 vim

--- a/packer/http/fedora-22/ks-openstack.cfg
+++ b/packer/http/fedora-22/ks-openstack.cfg
@@ -36,7 +36,9 @@ wget
 
 %post
 # update root certs
-wget -O/etc/pki/tls/certs/ca-bundle.crt https://hg.mozilla.org/releases/mozilla-release/raw-file/default/security/nss/lib/ckfw/builtins/certdata.txt
+wget https://raw.githubusercontent.com/bagder/curl/master/lib/mk-ca-bundle.pl
+perl mk-ca-bundle.pl /etc/pki/tls/certs/ca-bundle.crt
+rm certdata.txt mk-ca-bundle.pl
 # sudo
 echo 'Defaults:fedora !requiretty' > /etc/sudoers.d/fedora
 echo '%fedora ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers.d/fedora

--- a/packer/http/fedora-22/ks-openstack.cfg
+++ b/packer/http/fedora-22/ks-openstack.cfg
@@ -28,7 +28,7 @@ man
 man-pages
 net-tools
 nfs-utils
-perl
+perl-libwww-perl
 rsync
 tar
 vim

--- a/packer/http/fedora-22/ks-openstack.cfg
+++ b/packer/http/fedora-22/ks-openstack.cfg
@@ -28,6 +28,7 @@ man
 man-pages
 net-tools
 nfs-utils
+perl
 rsync
 tar
 vim


### PR DESCRIPTION
This will download and execute a perl script that downloads the Mozilla CA bundle over HTTPS and convert it from multiline octal to the more standard PEM. Resolves issue #11.
For what it's worth, I've only tested this on Fedora 22. However I expect it to work across all the affected platforms.
