### PR TITLE
Set epel to use our repos during installation

### DIFF
--- a/packer/scripts/centos/epel-6.sh
+++ b/packer/scripts/centos/epel-6.sh
@@ -1,3 +1,7 @@
 #!/bin/bash -eux
 
 rpm -Uvh http://epel.osuosl.org/6/x86_64/epel-release-6-8.noarch.rpm
+
+# use our mirror
+sed -i -e 's/^\(mirrorlist.*\)/#\1/g' /etc/yum.repos.d/epel.repo
+sed -i -e 's/^#baseurl=.*pub\/epel\/6\/$basearch$/baseurl=http:\/\/epel.osuosl.org\/6\/$basearch\//' /etc/yum.repos.d/epel.repo

--- a/packer/scripts/centos/epel-7.sh
+++ b/packer/scripts/centos/epel-7.sh
@@ -1,3 +1,7 @@
 #!/bin/bash -eux
 
 rpm -Uvh http://epel.osuosl.org/7/x86_64/e/epel-release-7-1.noarch.rpm
+
+# use our mirror
+sed -i -e 's/^\(mirrorlist.*\)/#\1/g' /etc/yum.repos.d/epel.repo
+sed -i -e 's/^#baseurl=.*pub\/epel\/7\/$basearch$/baseurl=http:\/\/epel.osuosl.org\/7\/$basearch\//' /etc/yum.repos.d/epel.repo


### PR DESCRIPTION
This ensures that we get a faster install and we don't run into issues if the
metalink is broken which happened today.
