### PR TITLE
Explicitly disable interactive keyboard and challenge response auth

### DIFF
--- a/packer/scripts/common/sshd.sh
+++ b/packer/scripts/common/sshd.sh
@@ -4,3 +4,4 @@ echo "UseDNS no" >> /etc/ssh/sshd_config
 echo "GSSAPIAuthentication no" >> /etc/ssh/sshd_config
 echo "ChallengeResponseAuthentication no" >> /etc/ssh/sshd_config
 echo "KbdInteractiveAuthentication no" >> /etc/ssh/sshd_config
+echo "PasswordAuthentication no" >> /etc/ssh/sshd_config

--- a/packer/scripts/common/sshd.sh
+++ b/packer/scripts/common/sshd.sh
@@ -3,4 +3,4 @@
 echo "UseDNS no" >> /etc/ssh/sshd_config
 echo "GSSAPIAuthentication no" >> /etc/ssh/sshd_config
 echo "ChallengeResponseAuthentication no" >> /etc/ssh/sshd_config
-echo "KbdInteractiveAuthentication dno" >> /etc/ssh/sshd_config
+echo "KbdInteractiveAuthentication no" >> /etc/ssh/sshd_config

--- a/packer/scripts/common/sshd.sh
+++ b/packer/scripts/common/sshd.sh
@@ -2,3 +2,5 @@
 
 echo "UseDNS no" >> /etc/ssh/sshd_config
 echo "GSSAPIAuthentication no" >> /etc/ssh/sshd_config
+echo "ChallengeResponseAuthentication no" >> /etc/ssh/sshd_config
+echo "KbdInteractiveAuthentication dno" >> /etc/ssh/sshd_config


### PR DESCRIPTION
Explicitly concat no for interactive keyboard and challenge response auth.

The security vuln we found in our OpenSUSE 42.2 images was fixed by just disabling ChallengeResponseAuthentication, but I think it is a good idea to disable interactive keyboard as well moving forward. I can't think of any good reason to leave it as default/yes, as it seems to have pretty close behavior to ChallengeResponseAuthentication and PasswordAuthentication and leaving it up to the distro may be a possible window for a future security hole. I am all for allowing keys and ONLY keys as authentication for these OpenStack instances.

I tested this by making an instance on OpenStack using the OpenSUSE 42.2 image and running the echo/concat command, logging in as root with password, restarting sshd, and no longer being able to login as root with password. Disabling KbdInteractiveAuthentication has no effect on the current way we access these machines (keys).